### PR TITLE
Improve readme

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at `INSERT-EMAIL@pdis.tw`. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at `INSERT-EMAIL@pdis.tw`. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team in [the Holopolis section of the PDIS discussion forum][forum]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
@@ -44,3 +44,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
+[forum]: https://talk.pdis.nat.gov.tw/c/holopolis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# How to Contribute
+
+Hey there! Glad that you're interested in contributing! We really
+appreciate it. :tada:
+
+We know that skills and expertise can vary greatly, so we organize this
+resource by the type of contributor you are. Please **follow the path that
+best describes you**:
+
+* [I'm moderately technical, and interested in working openly on
+  GitHub.][audience-technical]
+* [I don't have time to learn GitHub, but would love for someone to help me
+  make a change.][audience-no-github]
+
+## Contributing via GitHub
+
+### Background
+
+For a quick summary of technologies used, see the [README][tech-used].
+
+Here are the quick and dirty details that you should know about how we
+work.
+
+* For managing events, edit this file:
+  [`_data/events.yml`](_data/events.yml)
+* We share push access liberally. (Just [open an issue][new-issue] and ask!)
+* `master` branch is automatically deployed to our live website.
+* `master` branch is protected, and so can't be pushed to directly.
+* All changes are made through pull requests.
+
+### Step-by-Step
+
+Here are the general steps that we recommend you follow to get your
+improvements onto the website:
+
+1. **Before doing any work, open a new issue** to discuss your idea.
+   This helps ensure that our visions align. We'd hate for you to do
+   work that we then couldn't merge!
+2. Ask for push access. (We'll give it to you!)
+    * We use branch protection on `master`, so you can't push there.
+3. **Create a "topic branch"** in the main repo, describing your change. eg.
+   `my-special-feature`.
+4. Make some commits.
+5. As early as you'd like, **create a "pull request"** for your branch into
+   `master`.
+    * If your branch is in the main repo, you'll notice that a review app
+      will deployed with your code, and linked in the issue. This will
+      help us collaborate more smoothly.
+6. When you think your changes are ready, post a pull request comment to
+   say so, and **ask for a review**.
+7. **We'll review your changes** with the help of the Review App. Then we'll either:
+    1. merge them right away, or
+    2. ask you to make some changes.
+        - Don't worry! This is totally no big deal! Working together to get
+          things just right is a common dynamic in contributing to projects.
+          We'll work on it together.
+8. After coming to agreement on the best possible contribution, **we'll
+   merge your changes** into `master`!
+9. Your changes are now live on the website. Yay! Thanks a bunch!
+
+## Contributing without GitHub
+
+We totally get it: GitHub can be intimidating, and there's not always time to
+learn :slightly_smiling_face:
+
+The most accessible ways to get a change made is to reach out to us via:
+
+  * :speech_balloon: Discussion Forum:
+    [Category: Holopolis](https://talk.pdis.nat.gov.tw/c/holopolis)
+  * :bird: Twitter: [@TaiwanPDIS](https://twitter.com/TaiwanPDIS)
+
+<!-- Links -->
+   [forking]: https://guides.github.com/activities/forking/
+   [tech-used]: https://github.com/patcon/holopolis.pdis.tw/#technologies-used
+   [audience-technical]: #contributing-via-github
+   [audience-no-github]: #contributing-without-github
+   [new-issue]: https://github.com/patcon/holopolis.pdis.tw/issues/new

--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
-# holopolis-vue
+# holopolis.pdis.tw
 
-> A Vue.js project
+Static HTML website for [holopolis.pdis.tw](http://holopolis.pdis.tw), hosted
+on GitHub Pages.
 
-## Build Setup
+## :computer: Local Development
 
-``` bash
+### Technologies Used
+
+* [**GitHub Pages.**][gh-pages] An HTML website-hosting service provided by GitHub.
+* [**Heroku.**][heroku] A platform for easily deploying applications.
+* [**Review Apps.**][review-apps] A Heroku feature that deploys code
+  from GitHub pull requests as a disposable app on the web.
+* [**VueJS.**][vuejs] A progressive framework for building user
+  interfaces in JS.
+* [**Discourse.**][discourse] A modern Internet discussion platform.
+
+### Requirements
+
+* Node.JS (optional)
+* Python 3 (optional)
+
+### Build Setup
+
+Run the following commands within `docs/`:
+
+```bash
 # install dependencies
 npm install
 
@@ -28,3 +48,37 @@ npm test
 ```
 
 For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
+
+### Serving the website
+
+If you have Python installed, you can quickly serve by running the
+following from within `docs/`:
+
+```
+python3 -m http.server 3000
+```
+
+You will now be able to view it at: http://localhost:3000
+
+## :muscle: Contributing
+
+Please make sure to read our [Contributing Guide](CONTRIBUTING.md) and
+[Code of Conduct](CONDUCT.md) before making a pull request.
+
+### Get Involved
+
+If you'd like to join in on the conversation, great!
+
+We have a [specific section of our website][joinus] with details!
+
+## :copyright: License
+
+[MIT](https://opensource.org/licenses/MIT)
+
+<!-- Links -->
+   [gh-pages]: https://help.github.com/articles/what-is-github-pages/
+   [heroku]: https://www.heroku.com/what
+   [review-apps]: https://devcenter.heroku.com/articles/github-integration-review-apps
+   [vuejs]: https://vuejs.org/v2/guide/
+   [discourse]: https://www.discourse.org/about
+   [joinus]: http://holopolis.pdis.tw/joinus.html

--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "holopolis.pdis.tw",
+  "description": "The code for the holopolis.pdis.tw website.",
+  "scripts": {
+  },
+  "env": {
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+
+  ],
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-static"
+    }
+  ]
+}

--- a/static.json
+++ b/static.json
@@ -1,0 +1,4 @@
+{
+  "https_only": true,
+  "root": "docs/"
+}


### PR DESCRIPTION
If it's alright, I'd love to contribute some improvements so that people can dive in more easily :)

I've got some thoughts and scaffolding that I can pull from other projects, but I have some related questions first:

1. This website appears to be hosted on GitHub pages. Can we expect this to remain the case?
2. Can we move things back out of `docs/`? If it's all the same, I think this could simplify instructions and minimize confusion for when people are running setup commands we tell them to run :)
3. Is it alright to use heroku review apps? Example: https://github.com/CivicTechTO/codeacross.ca/pull/5 (see that repo's CONTRIBUTING.md for details)

Likely more questions to come :)

## To Do

- [x] admin grant @patcon's heroku app access to org - #5
- [x] add patcon as PDIS github org member (minimal role) - #5
- [x] repo admin give @patcon admin access on `holopolis.pdis.tw` repo
- [x] @patcon connect heroku app to `PDIS/holopolis.pdis.tw` repo
- [ ] @patcon merge this pull request
- [ ] @patcon enables review apps
- [ ] @patcon schedule call with @shuyanglin explaining review apps
- [ ] @patcon transfer heroku app ownership to pdis admin @shuyanglin 