### PR TITLE
Ensure that only image links are rendered in project cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -184,7 +184,7 @@
                   project.img = ''
                 }
                 else {
-                  project.img = res.data.post_stream.posts[0].link_counts[0].url
+                  project.img = res.data.post_stream.posts[0].link_counts.filter(link => /\.(gif|jpe?g|png)$/.test(link.url))[0].url
                 }
                 this.projects.push(project)
               })


### PR DESCRIPTION
Way back when, I added a link to [the project post on discourse](https://talk.pdis.nat.gov.tw/t/holopolis-hifi/3962
), and borked an assumption that the PDIS website was making. This fixes that :)

## Current

![screen shot 2018-10-23 at 4 17 34 pm](https://user-images.githubusercontent.com/305339/47346502-eb633a80-d6df-11e8-9046-64a7cd3cf867.png)

## Fixed

![screen shot 2018-10-23 at 4 17 15 pm](https://user-images.githubusercontent.com/305339/47346511-f1591b80-d6df-11e8-912e-88249e1a09e2.png)
